### PR TITLE
chore: update version to 15.3.0-SNAPSHOT and parent POM to 15.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-webapp-semantic-search</artifactId>
 	<packaging>jar</packaging>
 	<name>Semantic Search Webapp Plugin</name>
-	<version>15.2.1-SNAPSHOT</version>
+	<version>15.3.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-webapp-semantic-search.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-webapp-semantic-search.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.2.0</version>
+		<version>15.3.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary
   This PR updates the project version to 15.3.0-SNAPSHOT and updates the parent POM dependency to version 15.3.0.

   ## Changes Made
   - Updated `pom.xml` project version from `15.2.1-SNAPSHOT` to `15.3.0-SNAPSHOT`
   - Updated parent POM (`fess-parent`) version from `15.2.0` to `15.3.0`

   ## Testing
   - Build verification: `mvn clean package` should complete successfully
   - No functional changes - this is a version update only

   ## Breaking Changes
   None. This is a routine version update.

   ## Additional Notes
   This update aligns the plugin with the latest Fess parent POM release (15.3.0) and prepares for the next development cycle.