### PR TITLE
chore(deps): update parent POM version to 15.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.5.0-SNAPSHOT</version>
+		<version>15.5.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary
Update the fess-parent POM version from 15.5.0-SNAPSHOT to the released 15.5.0.

## Changes Made
- Updated `pom.xml` parent version from `15.5.0-SNAPSHOT` to `15.5.0`

## Testing
- Build verification should confirm compatibility with the released parent POM

## Breaking Changes
- None

## Additional Notes
- This aligns the project with the stable 15.5.0 release of fess-parent